### PR TITLE
Fixed the 'pager' config variable.  Was not picking up any user-supplied

### DIFF
--- a/litecli/main.py
+++ b/litecli/main.py
@@ -281,7 +281,7 @@ class LiteCli(object):
         """
         cnf = self.config
 
-        sections = ["client"]
+        sections = ["main"]
 
         def get(key):
             result = None


### PR DESCRIPTION
pager variable because the read_my_cnf_files method was expecting
a setting section called 'client' instead of 'main'.

Other functional callers to the read_my_cnf_files method/function
seem not to be affected by this probelm, most notably the prompt
config which manually overrode the None returned in lines
116-188 where after not finding prompt_cnf would use c["main"]["prompt"]

Tests seem to pass.

## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG` file.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
