### PR TITLE
Fix running tests in environment where opening /dev/tty gives ENXIO

### DIFF
--- a/litecli/main.py
+++ b/litecli/main.py
@@ -923,7 +923,7 @@ def cli(
 
         try:
             sys.stdin = open("/dev/tty")
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             litecli.logger.warning("Unable to open TTY as stdin.")
 
         if (


### PR DESCRIPTION
It can also throw OSError if system returns ENXIO (No such device or address)

## Description
<!--- Describe your changes in detail. -->
Fixes tests when ran in [Nix](https://nixos.org/nix/) sandbox


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG` file.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).