### PR TITLE
Add .read command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Bug Fixes:
 Features:
 ---------
 
+* Added `.read` command for reading scripts.
 * Added `.load` command for loading extension libraries. (Thanks: [Zhiming Wang])
 * Add support for using `?` as a placeholder in the favorite queries. (Thanks: [Amjith])
 * Added shift-tab to select the previous entry in the completion menu. [Amjith]
@@ -22,8 +23,5 @@ Features:
 
 
 [Amjith]: https://blog.amjith.com
-<<<<<<< HEAD
 [Zhiming Wang]: https://github.com/zmwangx
 [Irina Truong]: https://github.com/j-bennet
-=======
->>>>>>> master

--- a/litecli/AUTHORS
+++ b/litecli/AUTHORS
@@ -17,3 +17,4 @@ Contributors:
   * Thomas Roten
   * Zhaolong Zhu
   * Zhiming Wang
+  * Shawn M. Chapla

--- a/litecli/packages/special/dbcommands.py
+++ b/litecli/packages/special/dbcommands.py
@@ -168,3 +168,21 @@ def load_extension(cur, arg, **_):
     conn.enable_load_extension(True)
     conn.load_extension(path)
     return [(None, None, None, "")]
+
+
+@special_command(
+    ".read",
+    ".read path",
+    "Read input from path",
+    arg_type=PARSED_QUERY,
+    case_sensitive=True,
+)
+def read_script(cur, arg, **_):
+    args = shlex.split(arg)
+    if len(args) != 1:
+        raise TypeError(".read accepts exactly one path")
+    path = args[0]
+    with open(path, "r") as f:
+        script = f.read()
+        cur.executescript(script)
+    return [(None, None, None, "")]


### PR DESCRIPTION
## Description
Adds the .read command present in the CLI distributed with SQLite3 to allow for SQL "scripts" containing schemata etc. to be loaded from files.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG` file.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
(Neither of these files seem to exist, so I've done neither of these things.