### PR TITLE
Remove the double-quote escaping from the INSERT statement in .import…

### DIFF
--- a/litecli/packages/special/dbcommands.py
+++ b/litecli/packages/special/dbcommands.py
@@ -235,7 +235,7 @@ def import_file(cur, arg=None, **_):
     filename, table = args
     cur.execute("PRAGMA table_info(%s)" % table)
     ncols = len(cur.fetchall())
-    insert_tmpl = 'INSERT INTO "%s" VALUES (?%s)' % (table, ",?" * (ncols - 1))
+    insert_tmpl = "INSERT INTO %s VALUES (?%s)" % (table, ",?" * (ncols - 1))
 
     with open(filename, "r") as csvfile:
         dialect = csv.Sniffer().sniff(csvfile.read(1024))


### PR DESCRIPTION
… special command.

## Description

While testing the PR #79 I ran into an edge case where if I escaped the table name such as 

```
:memory:> create table temp (name text, id integer);
:memory:> .import ./import_data.csv `temp`
```

It would throw an error saying that table not found. This change fixes that edge case. 
