### PR TITLE
Fix `key word` and "key word" issue for .import command

### DIFF
--- a/litecli/packages/completion_engine.py
+++ b/litecli/packages/completion_engine.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import os
 import sys
-import shlex
 import sqlparse
 from sqlparse.sql import Comparison, Identifier, Where
 from sqlparse.compat import text_type
@@ -143,7 +142,7 @@ def _expecting_arg_idx(arg, text):
     >>> _expecting_arg_idx("./data.csv t", ".import ./data.csv t")
     2
     """
-    args = shlex.split(arg)
+    args = arg.split()
     return len(args) + int(text[-1].isspace())
 
 

--- a/tests/test_dbspecial.py
+++ b/tests/test_dbspecial.py
@@ -10,6 +10,8 @@ def test_import_first_argument():
         [".import ./da", 1],
         [".import ./data.csv ", 2],
         [".import ./data.csv t", 2],
+        [".import ./data.csv `t", 2],
+        ['.import ./data.csv "t', 2],
     ]
     for text, expecting_arg_idx in test_cases:
         suggestions = suggest_type(text, text)


### PR DESCRIPTION
## Description

Fix `key word` and "key word" issue for .import command. 

Related PR: https://github.com/dbcli/litecli/pull/80