### PR TITLE
removed is_dropping_database check (you cannot drop database in SQLite)

### DIFF
--- a/litecli/main.py
+++ b/litecli/main.py
@@ -529,10 +529,6 @@ class LiteCli(object):
                 logger.error("traceback: %r", traceback.format_exc())
                 self.echo(str(e), err=True, fg="red")
             else:
-                if is_dropping_database(text, self.sqlexecute.dbname):
-                    self.sqlexecute.dbname = None
-                    self.sqlexecute.connect()
-
                 # Refresh the table names and column names if necessary.
                 if need_completion_refresh(text):
                     self.refresh_completions(reset=need_completion_reset(text))
@@ -964,31 +960,6 @@ def need_completion_refresh(queries):
                 return True
         except Exception:
             return False
-
-
-def is_dropping_database(queries, dbname):
-    """Determine if the query is dropping a specific database."""
-    if dbname is None:
-        return False
-
-    def normalize_db_name(db):
-        return db.lower().strip('`"')
-
-    dbname = normalize_db_name(dbname)
-
-    for query in sqlparse.parse(queries):
-        if query.get_name() is None:
-            continue
-
-        first_token = query.token_first(skip_cm=True)
-        _, second_token = query.token_next(0, skip_cm=True)
-        database_name = normalize_db_name(query.get_name())
-        if (
-            first_token.value.lower() == "drop"
-            and second_token.value.lower() in ("database", "schema")
-            and database_name == dbname
-        ):
-            return True
 
 
 def need_completion_reset(queries):


### PR DESCRIPTION
I've been checking if the issue with the new `sqlparse` from mycli (https://github.com/dbcli/mycli/pull/819) applies here, and sure it does. It does not break anything because `is_dropping_database()` is always false anyway. Still, no need to keep this code.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md` file.
