### PR TITLE
Fix compatibility with sqlparse >= 0.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Bug Fixes:
 ----------
 
 * Fix setup.py to set long_description_content_type as markdown.
+* Fix compatibility with sqlparse >= 0.4.0.
 
 
 1.4.0:
@@ -29,12 +30,12 @@ Features:
 1.3.2:
 ======
 
-* Fix the completion engine to work with newer sqlparse. 
+* Fix the completion engine to work with newer sqlparse.
 
 1.3.1:
 ======
 
-* Remove the version pinning of sqlparse package. 
+* Remove the version pinning of sqlparse package.
 
 
 Features:

--- a/litecli/encodingutils.py
+++ b/litecli/encodingutils.py
@@ -5,11 +5,13 @@ from litecli.compat import PY2
 
 
 if PY2:
-    text_type = unicode
     binary_type = str
+    string_types = basestring
+    text_type = unicode
 else:
-    text_type = str
     binary_type = bytes
+    string_types = str
+    text_type = str
 
 
 def unicode2utf8(arg):

--- a/litecli/packages/completion_engine.py
+++ b/litecli/packages/completion_engine.py
@@ -2,17 +2,9 @@ from __future__ import print_function
 import sys
 import sqlparse
 from sqlparse.sql import Comparison, Identifier, Where
-from sqlparse.compat import text_type
+from litecli.encodingutils import string_types, text_type
 from .parseutils import last_word, extract_tables, find_prev_keyword
 from .special import parse_special_command
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
-
-if PY3:
-    string_types = str
-else:
-    string_types = basestring
 
 
 def suggest_type(full_text, text_before_cursor):


### PR DESCRIPTION
## Description

sqlparse [v0.4.0](https://github.com/andialbrecht/sqlparse/blob/fe39072fc24e879034fb1e439fb0a47c7c66d4a2/CHANGELOG#L15) (October 7, 2020) has [removed](https://github.com/andialbrecht/sqlparse/commit/3e3892f939031d58d98275ce8a237689225d299a) `sqlparse.compat`, which results in the following error when launching litecli with the latest version of sqlparse installed:

```
Traceback (most recent call last):
  File "/usr/bin/litecli", line 33, in <module>
    sys.exit(load_entry_point('litecli==1.3.2', 'console_scripts', 'litecli')())
  File "/usr/bin/litecli", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/lib/python3.8/site-packages/litecli/main.py", line 36, in <module>
    from .sqlcompleter import SQLCompleter
  File "/usr/lib/python3.8/site-packages/litecli/sqlcompleter.py", line 9, in <module>
    from .packages.completion_engine import suggest_type
  File "/usr/lib/python3.8/site-packages/litecli/packages/completion_engine.py", line 5, in <module>
    from sqlparse.compat import text_type
ModuleNotFoundError: No module named 'sqlparse.compat'
```

Since only one trivial type is imported from `sqlparse.compat`, this PR moves it into `encodingutils.py`.

## Environment

- **OS**: Linux (Arch)
- **litecli**: 1.3.2-1
- **litecli-git**: v0.0.3.r1.g08d6953-1
- **python-sqlparse**: 0.4.1-1
- **Cc**: @randrej

## Checklist

- [x] I've added this contribution to the `changelog.md` file.