### PR TITLE
\f prompt format string for database basename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add verbose feature to `favorite_query` command. (Thanks: [Zhaolong Zhu])
   - `\f query` does not show the full SQL.
   - `\f+ query` shows the full SQL.
+- Add prompt format of file's basename. (Thanks: [elig0n])
 
 ### Bug Fixes
 

--- a/litecli/liteclirc
+++ b/litecli/liteclirc
@@ -54,7 +54,8 @@ wider_completion_menu = False
 
 # litecli prompt
 # \D - The full current date
-# \d - Database name
+# \d - Database full path
+# \f - Database base-name
 # \m - Minutes of the current time
 # \n - Newline
 # \P - AM/PM

--- a/litecli/liteclirc
+++ b/litecli/liteclirc
@@ -54,8 +54,8 @@ wider_completion_menu = False
 
 # litecli prompt
 # \D - The full current date
-# \d - Database full path
-# \f - Database base-name
+# \d - Database name
+# \f - File basename of the "main" database
 # \m - Minutes of the current time
 # \n - Newline
 # \P - AM/PM

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -725,6 +725,7 @@ class LiteCli(object):
         sqlexecute = self.sqlexecute
         now = datetime.now()
         string = string.replace("\\d", sqlexecute.dbname or "(none)")
+        string = string.replace("\\f", os.path.basename(sqlexecute.dbname or "(none)"))
         string = string.replace("\\n", "\n")
         string = string.replace("\\D", now.strftime("%a %b %d %H:%M:%S %Y"))
         string = string.replace("\\m", now.strftime("%M"))

--- a/tests/liteclirc
+++ b/tests/liteclirc
@@ -53,7 +53,8 @@ wider_completion_menu = False
 
 # litecli prompt
 # \D - The full current date
-# \d - Database name
+# \d - Database full path
+# \f - Database base-name
 # \m - Minutes of the current time
 # \n - Newline
 # \P - AM/PM

--- a/tests/liteclirc
+++ b/tests/liteclirc
@@ -53,8 +53,8 @@ wider_completion_menu = False
 
 # litecli prompt
 # \D - The full current date
-# \d - Database full path
-# \f - Database base-name
+# \d - Database name
+# \f - File basename of the "main" database
 # \m - Minutes of the current time
 # \n - Newline
 # \P - AM/PM


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
The prompt format string `\d` (which is also the default) is replaced with the full path to the open database, even when the database file is in the current directory.

## The Problem
This can get long sometimes and make the prompt input line shortened very much, especially on small terminals.
Some users might desire to display the shortened base-name version of the database for convenience.

## Suggested Solution
Hence, I've added the option `\f` for showing only the basename.
Otherwise, a relative-path sensitivity for the `\d` format string should be implemented.

## Checklist
- [ ] I will add this contribution to `CHANGELOG.md` if I get an OK