### PR TITLE
Make it possible to use .once more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug Fixes
+
+* Fix [[#146](https://github.com/dbcli/litecli/issues/146)], making sure `.once`
+  can be used more than once in a session.
+
 ## 1.9.0 - 2022-06-06
 
 ### Features

--- a/litecli/packages/special/iocommands.py
+++ b/litecli/packages/special/iocommands.py
@@ -405,9 +405,9 @@ def write_once(output):
 @export
 def unset_once_if_written():
     """Unset the once file, if it has been written to."""
-    global once_file
+    global once_file, written_to_once_file
     if written_to_once_file:
-        once_file = None
+        once_file = written_to_once_file = None
 
 
 @special_command(


### PR DESCRIPTION
## Description

When .once has been used, reset `written_to_once_file` as otherwise `once_file` is cleared after every subsequent command, including additional `.once` commands.

Fixes #146.

## Checklist

- [X ] I've added this contribution to the `CHANGELOG.md` file.
