### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ You'll always get credit for your work.
     $ pip install --editable .
     ```
 
-6. Create a branch for your bugfix or feature based off the `master` branch:
+6. Create a branch for your bugfix or feature based off the `main` branch:
 
     ```bash
     $ git checkout -b <name-of-bugfix-or-feature>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ You'll always get credit for your work.
 7. While you work on your bugfix or feature, be sure to pull the latest changes from `upstream`. This ensures that your local codebase is up-to-date:
 
     ```bash
-    $ git pull upstream master
+    $ git pull upstream main
     ```
 
 8. When your work is ready for the litecli team to review it, push your branch to your fork:


### PR DESCRIPTION
Changed `git pull upstream master` to `git pull upstream main` to reflect changes to Github naming. Only a minor edit to the contributing document.

## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG.md` file.
