### PR TITLE
Fixing startupcommands and successful perpetually set as True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## TBD
 
+### Features
+
+* Adding support for startup commands being set in liteclirc and executed on startup. Limited to commands already implemented in litecli. ([[#56](https://github.com/dbcli/litecli/issues/56)])
+
 ### Bug Fixes
 
 * Fix [[#146](https://github.com/dbcli/litecli/issues/146)], making sure `.once`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Fix [[#146](https://github.com/dbcli/litecli/issues/146)], making sure `.once`
   can be used more than once in a session.
+* Fixed setting `successful = True` only when query is executed without exceptions so 
+  failing queries get `successful = False` in `query_history`.
+* Changed `master` to `main` in CONTRIBUTING.md to reflect GitHubs new default branch 
+  naming.
 
 ## 1.9.0 - 2022-06-06
 
@@ -115,3 +119,4 @@
 [Shawn Chapla]: https://github.com/shwnchpl
 [Zhaolong Zhu]: https://github.com/zzl0
 [Zhiming Wang]: https://github.com/zmwangx
+[Bjørnar Smestad]: https://brendesmestad.no

--- a/litecli/liteclirc
+++ b/litecli/liteclirc
@@ -117,6 +117,12 @@ output.header = "#00ff5f bold"
 output.odd-row = ""
 output.even-row = ""
 
-
 # Favorite queries.
 [favorite_queries]
+
+# Startup commands
+# litecli commands or sqlite commands to be executed on startup.
+# some of them will require you to have a database attached. 
+# they will be executed in the same order as they appear in the list.
+[startup_commands]
+#commands = ".tables", "pragma foreign_keys = ON;"

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -442,7 +442,6 @@ class LiteCli(object):
                 start = time()
                 res = sqlexecute.run(text)
                 self.formatter.query = text
-                successful = True
                 result_count = 0
                 for title, cur, headers, status in res:
                     logger.debug("headers: %r", headers)
@@ -457,6 +456,8 @@ class LiteCli(object):
                         if not confirm("Do you want to continue?"):
                             self.echo("Aborted!", err=True, fg="red")
                             break
+                        else:
+                            successful = True
 
                     if self.auto_vertical_output:
                         max_width = self.prompt_app.output.get_size().columns
@@ -475,6 +476,8 @@ class LiteCli(object):
                             self.output(formatted, status)
                         except KeyboardInterrupt:
                             pass
+                        else:
+                            successful = True
                         self.echo("Time: %0.03fs" % t)
                     except KeyboardInterrupt:
                         pass

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -115,7 +115,7 @@ class LiteCli(object):
             self.startup_commands = c["startup_commands"]
         except KeyError: # Redundant given the load_config() function that merges in the standard config, but put here to avoid fail if user do not have updated config file.
             self.startup_commands = None
-       
+
         self.completion_refresher = CompletionRefresher()
 
         self.logger = logging.getLogger(__name__)
@@ -595,7 +595,6 @@ class LiteCli(object):
                 search_ignore_case=True,
             )
         def startup_commands():
-            #TODO: Wait for attach db
             if self.startup_commands:
                 if "commands" in self.startup_commands:
                     for command in self.startup_commands['commands']:
@@ -613,7 +612,6 @@ class LiteCli(object):
                                     output = self.format_output(title, cur, headers)
                                     for line in output:
                                         self.echo(line)
-                            
                 else:
                     self.echo("Could not read commands. The startup commands needs to be formatted as: \n commands = 'command1', 'command2', ...", fg="yellow")
 

--- a/litecli/packages/special/utils.py
+++ b/litecli/packages/special/utils.py
@@ -51,8 +51,14 @@ def format_uptime(uptime_in_seconds):
 def check_if_sqlitedotcommand(command):
     """Does a check if the command supplied is in the list of SQLite dot commands.
 
-    :param command: A command supplied from the user
+    :param command: A command (str) supplied from the user
     :returns: True/False
     """
+
     sqlite3dotcommands = ['.archive','.auth','.backup','.bail','.binary','.cd','.changes','.check','.clone','.connection','.databases','.dbconfig','.dbinfo','.dump','.echo','.eqp','.excel','.exit','.expert','.explain','.filectrl','.fullschema','.headers','.help','.import','.imposter','.indexes','.limit','.lint','.load','.log','.mode','.nonce','.nullvalue','.once','.open','.output','.parameter','.print','.progress','.prompt','.quit','.read','.recover','.restore','.save','.scanstats','.schema','.selftest','.separator','.session','.sha3sum','.shell','.show','.stats','.system','.tables','.testcase','.testctrl','.timeout','.timer','.trace','.vfsinfo','.vfslist','.vfsname','.width']
-    return (command.lower() in sqlite3dotcommands)
+
+    if isinstance(command, str):
+        command = command.split(' ', 1)[0].lower()
+        return (command in sqlite3dotcommands)
+    else:
+        return False

--- a/litecli/packages/special/utils.py
+++ b/litecli/packages/special/utils.py
@@ -46,3 +46,14 @@ def format_uptime(uptime_in_seconds):
 
     uptime = " ".join(uptime_values)
     return uptime
+
+def check_if_sqlitedotcommand(command):
+    """Does a check if the command supplied is in the list of SQLite dot commands.
+
+    :param command: A command supplied from the user
+    :returns: True/False
+    """
+
+
+    sqlite3dotcommands = ['.archive','.auth','.backup','.bail','.binary','.cd','.changes','.check','.clone','.connection','.databases','.dbconfig','.dbinfo','.dump','.echo','.eqp','.excel','.exit','.expert','.explain','.filectrl','.fullschema','.headers','.help','.import','.imposter','.indexes','.limit','.lint','.load','.log','.mode','.nonce','.nullvalue','.once','.open','.output','.parameter','.print','.progress','.prompt','.quit','.read','.recover','.restore','.save','.scanstats','.schema','.selftest','.separator','.session','.sha3sum','.shell','.show','.stats','.system','.tables','.testcase','.testctrl','.timeout','.timer','.trace','.vfsinfo','.vfslist','.vfsname','.width']
+    return (command.lower() in sqlite3dotcommands)

--- a/litecli/packages/special/utils.py
+++ b/litecli/packages/special/utils.py
@@ -47,13 +47,12 @@ def format_uptime(uptime_in_seconds):
     uptime = " ".join(uptime_values)
     return uptime
 
+
 def check_if_sqlitedotcommand(command):
     """Does a check if the command supplied is in the list of SQLite dot commands.
 
     :param command: A command supplied from the user
     :returns: True/False
     """
-
-
     sqlite3dotcommands = ['.archive','.auth','.backup','.bail','.binary','.cd','.changes','.check','.clone','.connection','.databases','.dbconfig','.dbinfo','.dump','.echo','.eqp','.excel','.exit','.expert','.explain','.filectrl','.fullschema','.headers','.help','.import','.imposter','.indexes','.limit','.lint','.load','.log','.mode','.nonce','.nullvalue','.once','.open','.output','.parameter','.print','.progress','.prompt','.quit','.read','.recover','.restore','.save','.scanstats','.schema','.selftest','.separator','.session','.sha3sum','.shell','.show','.stats','.system','.tables','.testcase','.testctrl','.timeout','.timer','.trace','.vfsinfo','.vfslist','.vfsname','.width']
     return (command.lower() in sqlite3dotcommands)

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -8,13 +8,15 @@ import sqlparse
 import os.path
 
 from .packages import special
-
 _logger = logging.getLogger(__name__)
 
 # FIELD_TYPES = decoders.copy()
 # FIELD_TYPES.update({
 #     FIELD_TYPE.NULL: type(None)
 # })
+
+sqlite3dotcommands = ['.archive','.auth','.backup','.bail','.binary','.cd','.changes','.check','.clone','.connection','.databases','.dbconfig','.dbinfo','.dump','.echo','.eqp','.excel','.exit','.expert','.explain','.filectrl','.fullschema','.headers','.help','.import','.imposter','.indexes','.limit','.lint','.load','.log','.mode','.nonce','.nullvalue','.once','.open','.output','.parameter','.print','.progress','.prompt','.quit','.read','.recover','.restore','.save','.scanstats','.schema','.selftest','.separator','.session','.sha3sum','.shell','.show','.stats','.system','.tables','.testcase','.testctrl','.timeout','.timer','.trace','.vfsinfo','.vfslist','.vfsname','.width']
+
 
 
 class SQLExecute(object):
@@ -79,6 +81,7 @@ class SQLExecute(object):
         # retrieve connection id
         self.reset_connection_id()
 
+
     def run(self, statement):
         """Execute the sql in the database and return the results. The results
         are a list of tuples. Each tuple has 4 values
@@ -129,10 +132,14 @@ class SQLExecute(object):
                 for result in special.execute(cur, sql):
                     yield result
             except special.CommandNotFound:  # Regular SQL
-                _logger.debug("Regular sql statement. sql: %r", sql)
-                cur.execute(sql)
-                yield self.get_result(cur)
-
+                basecommand = sql.split(' ', 1)[0]
+                if basecommand.lower() in sqlite3dotcommands:
+                    yield ('dot command not implemented', None, None, None)
+                else:
+                    _logger.debug("Regular sql statement. sql: %r", sql)
+                    cur.execute(sql)
+                    yield self.get_result(cur)
+    
     def get_result(self, cursor):
         """Get the current result's data from the cursor."""
         title = headers = None

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -3,7 +3,7 @@ import sqlite3
 import uuid
 from contextlib import closing
 from sqlite3 import OperationalError
-from .packages.special.utils import check_if_sqlitedotcommand
+from litecli.packages.special.utils import check_if_sqlitedotcommand
 
 import sqlparse
 import os.path

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -129,8 +129,7 @@ class SQLExecute(object):
                 for result in special.execute(cur, sql):
                     yield result
             except special.CommandNotFound:  # Regular SQL
-                basecommand = sql.split(' ', 1)[0]
-                if check_if_sqlitedotcommand(basecommand):
+                if check_if_sqlitedotcommand(sql):
                     yield ('dot command not implemented', None, None, None)
                 else:
                     _logger.debug("Regular sql statement. sql: %r", sql)

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -3,6 +3,7 @@ import sqlite3
 import uuid
 from contextlib import closing
 from sqlite3 import OperationalError
+from .packages.special.utils import check_if_sqlitedotcommand
 
 import sqlparse
 import os.path
@@ -14,10 +15,6 @@ _logger = logging.getLogger(__name__)
 # FIELD_TYPES.update({
 #     FIELD_TYPE.NULL: type(None)
 # })
-
-sqlite3dotcommands = ['.archive','.auth','.backup','.bail','.binary','.cd','.changes','.check','.clone','.connection','.databases','.dbconfig','.dbinfo','.dump','.echo','.eqp','.excel','.exit','.expert','.explain','.filectrl','.fullschema','.headers','.help','.import','.imposter','.indexes','.limit','.lint','.load','.log','.mode','.nonce','.nullvalue','.once','.open','.output','.parameter','.print','.progress','.prompt','.quit','.read','.recover','.restore','.save','.scanstats','.schema','.selftest','.separator','.session','.sha3sum','.shell','.show','.stats','.system','.tables','.testcase','.testctrl','.timeout','.timer','.trace','.vfsinfo','.vfslist','.vfsname','.width']
-
-
 
 class SQLExecute(object):
 
@@ -133,13 +130,13 @@ class SQLExecute(object):
                     yield result
             except special.CommandNotFound:  # Regular SQL
                 basecommand = sql.split(' ', 1)[0]
-                if basecommand.lower() in sqlite3dotcommands:
+                if check_if_sqlitedotcommand(basecommand):
                     yield ('dot command not implemented', None, None, None)
                 else:
                     _logger.debug("Regular sql statement. sql: %r", sql)
                     cur.execute(sql)
                     yield self.get_result(cur)
-    
+
     def get_result(self, cursor):
         """Get the current result's data from the cursor."""
         title = headers = None

--- a/tests/liteclirc
+++ b/tests/liteclirc
@@ -140,5 +140,5 @@ sh_param = select * from test where id=$1
 # litecli commands or sqlite commands to be executed on startup.
 # some of them will require you to have a database attached. 
 # they will be executed in the same order as they appear in the list.
-# Startup commands
-#commands = ".tables", "pragma foreign_keys = ON;"
+[startup_commands]
+commands = "create table startupcommands(a text)", "insert into startupcommands values('abc')"

--- a/tests/liteclirc
+++ b/tests/liteclirc
@@ -135,3 +135,10 @@ Token.Toolbar.Arg.Text = nobold
 [favorite_queries]
 q_param = select * from test where name=?
 sh_param = select * from test where id=$1
+
+# Startup commands
+# litecli commands or sqlite commands to be executed on startup.
+# some of them will require you to have a database attached. 
+# they will be executed in the same order as they appear in the list.
+# Startup commands
+#commands = ".tables", "pragma foreign_keys = ON;"

--- a/tests/test_dbspecial.py
+++ b/tests/test_dbspecial.py
@@ -1,6 +1,7 @@
 from litecli.packages.completion_engine import suggest_type
 from test_completion_engine import sorted_dicts
 from litecli.packages.special.utils import format_uptime
+from litecli.packages.special.utils import check_if_sqlitedotcommand
 
 
 def test_import_first_argument():
@@ -74,3 +75,15 @@ def test_indexes():
             {"type": "schema"},
         ]
     )
+
+
+def test_check_if_sqlitedotcommand():
+    test_cases = [
+        [".tables", True],
+        [".BiNarY", True],
+        ["binary", False],
+        [234, False],
+        [".changes   test! test", True],
+        ["NotDotcommand", False]]
+    for command, expected_result in test_cases:
+        assert check_if_sqlitedotcommand(command) == expected_result

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -260,3 +260,10 @@ def test_import_command(executor):
 """
     assert result.exit_code == 0
     assert expected in "".join(result.output)
+
+
+def test_startup_commands(executor):
+    m = LiteCli(liteclirc=default_config_file)
+    assert m.startup_commands['commands'] == ['create table startupcommands(a text)', "insert into startupcommands values('abc')"]
+
+    # implement tests on executions of the startupcommands


### PR DESCRIPTION
## Description

### Startup commands

As seen in https://github.com/dbcli/litecli/issues/56 there is a wish for having the option to define a set of commands that are to be executed on startup of litecli. For my case this would for instance be `.tables` - as I always seem to forget their names.

Startupcommands are set in liteclirc, I chose this rather than a new rc file to keep things simple.

```
# Startup commands
# litecli commands or sqlite commands to be executed on startup.
# some of them will require you to have a database attached. 
# they will be executed in the same order as they appear in the list.
[startup_commands]
#commands = ".tables", "pragma foreign_keys = ON;"
```

As I wanted to keep in line with the rest of the codebase the commands are executed using `sqlexecute.run(command)` in the `startup_commands()` function that loops through all the startup commands at startup. To facilitate for helpful error messaging I have also added `check_if_sqlitedotcommand(command)` that is invoked inside `sqlexecute.run()` to check if the command the user is trying to execute is indeed a valid dotcommand, however it is not implemented yet. I though this would be nice so the users doesn't question whether they had a spelling error in their command in those cases.

With this implementation there may be a wish to be able to utilize more of the dot commands or other special commands from SQLite - should we implement more of these into LiteCLI? Or is it to whish to not expand the range of special commands offered?



### Successfull perpetually set as True

Queries are amongst others logged into `self.query_history` which can also be accessed through `self.get_last_query`. Here they are stored as `"Query", ["query", "successful", "mutating"]`.

`successful` is set [in main.py](https://github.com/dbcli/litecli/blob/main/litecli/main.py#L441) , `successful = False`. This was undoubtedly with the intention to set `successful = True` at successful execution of queries. However I have found that failing queries are set as successful simply because the program will continue to run after the intial ` res = sqlexecute.run(text)` and thus set `successful = True`

Testcase, hardcoded, from [this line](https://github.com/dbcli/litecli/blob/main/litecli/main.py#L441):

                successful = False
                start = time()
                text = "this-is-not-a-query;"
                res = sqlexecute.run(text)
                self.formatter.query = text
                successful = True


My fix is to only set successful = True in the subsequent execution logic, often as an `else:` in the `try/except:` statements. 

If the intention was that the definition of successful = True is that a query is handled in any way this pull request can be disregarded, however please consider this interpretation of the logic as that makes it easier to access failed queries. 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG.md` file.

Note: One test is failing, this is unrelated to these changes as it fails on the code from the main branch as well, see [issue 153](https://github.com/dbcli/litecli/issues/153)