### PR TITLE
Fix: 'describe' command doesn't appear in 'help'

### DIFF
--- a/litecli/packages/special/dbcommands.py
+++ b/litecli/packages/special/dbcommands.py
@@ -212,7 +212,7 @@ def load_extension(cur, arg, **_):
     "Description of a table",
     arg_type=PARSED_QUERY,
     case_sensitive=True,
-    aliases=("\\d", "describe", "desc"),
+    aliases=("\\d", "desc"),
 )
 def describe(cur, arg, **_):
     if arg:


### PR DESCRIPTION
Fix for the 'describe' command not appearing when user requests 'help'.

## Description
'describe' doesn't appear because that string 'describe' also appears in describe()'s aliases.  This causes show_help() to skip it altogether, because aliases are added to COMMANDS with 'hidden=True' (in special/main.py:register_special_command()), which overwrites the original 'describe' entry in COMMANDS.

Fix: I removed 'describe' from describe()'s aliases list

## Checklist
- [ ] I've added this contribution to the `CHANGELOG.md` file.
