### PR TITLE
Add key binding to accept completion with the right-arrow key

### DIFF
--- a/litecli/key_bindings.py
+++ b/litecli/key_bindings.py
@@ -81,4 +81,12 @@ def cli_bindings(cli):
         b = event.app.current_buffer
         b.complete_state = None
 
+    @kb.add("right", filter=completion_is_selected)
+    def _(event):
+        """Accept the completion that is selected in the dropdown menu."""
+        _logger.debug("Detected right-arrow key.")
+
+        b = event.app.current_buffer
+        b.complete_state = None
+
     return kb

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -376,7 +376,7 @@ def test_auto_escaped_col_names(completer, complete_event):
             Completion(text="id", start_position=0),
         ]
         + list(map(Completion, completer.functions))
-        + [Completion(text="`select`", start_position=0)]
+        + [Completion(text="select", start_position=0)]
         + list(map(Completion, sorted(completer.keywords)))
     )
 


### PR DESCRIPTION
## Description

zsh-autosuggestions uses right-arrow to select a suggestion.  I found that I end up hitting right-arrow often when using litecli.  This change adds a key binding for right-arrow to accept a completion. 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG.md` file.
