### PR TITLE
Use sqlite3 API to cancel running queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   failing queries get `successful = False` in `query_history`.
 * Changed `master` to `main` in CONTRIBUTING.md to reflect GitHubs new default branch 
   naming.
+* Use the sqlite3 API to cancel a running query on interrupt
+  ([#164](https://github.com/dbcli/litecli/issues/164)).
 
 ## 1.9.0 - 2022-06-06
 

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -490,29 +490,17 @@ class LiteCli(object):
             except EOFError as e:
                 raise e
             except KeyboardInterrupt:
-                # get last connection id
-                connection_id_to_kill = sqlexecute.connection_id
-                logger.debug("connection id to kill: %r", connection_id_to_kill)
-                # Restart connection to the database
-                sqlexecute.connect()
                 try:
-                    for title, cur, headers, status in sqlexecute.run(
-                        "kill %s" % connection_id_to_kill
-                    ):
-                        status_str = str(status).lower()
-                        if status_str.find("ok") > -1:
-                            logger.debug(
-                                "cancelled query, connection id: %r, sql: %r",
-                                connection_id_to_kill,
-                                text,
-                            )
-                            self.echo("cancelled query", err=True, fg="red")
+                    sqlexecute.conn.interrupt()
                 except Exception as e:
                     self.echo(
                         "Encountered error while cancelling query: {}".format(e),
                         err=True,
                         fg="red",
                     )
+                else:
+                    logger.debug("cancelled query")
+                    self.echo("cancelled query", err=True, fg="red")
             except NotImplementedError:
                 self.echo("Not Yet Implemented.", fg="yellow")
             except OperationalError as e:

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -1,6 +1,5 @@
 import logging
 import sqlite3
-import uuid
 from contextlib import closing
 from sqlite3 import OperationalError
 from litecli.packages.special.utils import check_if_sqlitedotcommand
@@ -51,7 +50,6 @@ class SQLExecute(object):
     def __init__(self, database):
         self.dbname = database
         self._server_type = None
-        self.connection_id = None
         self.conn = None
         if not database:
             _logger.debug("Database is not specified. Skip connection.")
@@ -76,8 +74,6 @@ class SQLExecute(object):
         # Update them after the connection is made to ensure that it was a
         # successful connection.
         self.dbname = db
-        # retrieve connection id
-        self.reset_connection_id()
 
     def run(self, statement):
         """Execute the sql in the database and return the results. The results
@@ -207,17 +203,3 @@ class SQLExecute(object):
     def server_type(self):
         self._server_type = ("sqlite3", "3")
         return self._server_type
-
-    def get_connection_id(self):
-        if not self.connection_id:
-            self.reset_connection_id()
-        return self.connection_id
-
-    def reset_connection_id(self):
-        # Remember current connection id
-        _logger.debug("Get current connection id")
-        # res = self.run('select connection_id()')
-        self.connection_id = uuid.uuid4()
-        # for title, cur, headers, status in res:
-        #     self.connection_id = cur.fetchone()[0]
-        _logger.debug("Current connection id: %s", self.connection_id)


### PR DESCRIPTION
This fixes #164.

Since the interrupt handler was the only code that referenced
`sqlexecute.connection_id`, and the connection ids is merely a random
UUID without any meaning, the code generating that UUID can be removed
as well.

