### PR TITLE
Open once_file once per use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   failing queries get `successful = False` in `query_history`.
 * Changed `master` to `main` in CONTRIBUTING.md to reflect GitHubs new default branch 
   naming.
+* Fixed `.once -o <file>` by opening the output file once per statement instead
+  of for every line of output ([#148](https://github.com/dbcli/litecli/issues/148)).
 
 ## 1.9.0 - 2022-06-06
 


### PR DESCRIPTION
It was being re-opened for every single line of output, which prevented `.once -o ...` from working, plus this is a lot more efficient for long result sets.

Fixes #148.