### PR TITLE
Skip internal indexes in .schema output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   of for every line of output ([#148](https://github.com/dbcli/litecli/issues/148)).
 * Use the sqlite3 API to cancel a running query on interrupt
   ([#164](https://github.com/dbcli/litecli/issues/164)).
+* Skip internal indexes in the .schema output
+  ([#170](https://github.com/dbcli/litecli/issues/170)).
 
 
 ## 1.9.0 - 2022-06-06

--- a/litecli/packages/special/dbcommands.py
+++ b/litecli/packages/special/dbcommands.py
@@ -69,13 +69,14 @@ def show_schema(cur, arg=None, **_):
         args = (arg,)
         query = """
             SELECT sql FROM sqlite_master
-            WHERE name==?
+            WHERE name==? AND sql IS NOT NULL
             ORDER BY tbl_name, type DESC, name
         """
     else:
         args = tuple()
         query = """
             SELECT sql FROM sqlite_master
+            WHERE sql IS NOT NULL
             ORDER BY tbl_name, type DESC, name
         """
 


### PR DESCRIPTION
See the [schema table `sql` column documentation][schema]:

> The `sqlite_schema.sql` is NULL for the internal indexes that are automatically
> created by UNIQUE or PRIMARY KEY constraints.

[schema]: https://www.sqlite.org/schematab.html#interpretation_of_the_schema_table

Fixes #170
