### PR TITLE
Do not crash if ~/.config/litecli is not writeable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Next Release - [TBD]
+
+### Bug Fixes
+
+* Do not crash at start up if ~/.config/litecli is not writeable. [#172](https://github.com/dbcli/litecli/issues/172)
+
+
 ## 1.10.0 - 2022-11-19
 
 ### Features

--- a/litecli/config.py
+++ b/litecli/config.py
@@ -57,6 +57,10 @@ def get_config(liteclirc_file=None):
     liteclirc_file = liteclirc_file or "%sconfig" % config_location()
 
     default_config = os.path.join(package_root, "liteclirc")
-    write_default_config(default_config, liteclirc_file)
+    try:
+        write_default_config(default_config, liteclirc_file)
+    except OSError:
+        # If we can't write to the config file, just use the default config
+        return load_config(default_config)
 
     return load_config(liteclirc_file, default_config)

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -239,7 +239,11 @@ class LiteCli(object):
         log_file = self.config["main"]["log_file"]
         if log_file == "default":
             log_file = config_location() + "log"
-        ensure_dir_exists(log_file)
+        try:
+            ensure_dir_exists(log_file)
+        except OSError:
+            # Unable to create log file, log to temp directory instead.
+            log_file = "/tmp/litecli.log"
 
         log_level = self.config["main"]["log_level"]
 


### PR DESCRIPTION
## Description

Fixes #172 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `CHANGELOG.md` file.
