### PR TITLE
Fix warnings about invalid escape sequences

### DIFF
--- a/litecli/main.py
+++ b/litecli/main.py
@@ -329,7 +329,7 @@ class LiteCli(object):
             exit(1)
 
     def handle_editor_command(self, text):
-        """Editor command is any query that is prefixed or suffixed by a '\e'.
+        R"""Editor command is any query that is prefixed or suffixed by a '\e'.
         The reason for a while loop is because a user might edit a query
         multiple times. For eg:
 

--- a/litecli/packages/parseutils.py
+++ b/litecli/packages/parseutils.py
@@ -12,12 +12,12 @@ cleanup_regex = {
     # This matches everything except spaces, parens, colon, comma, and period
     "most_punctuations": re.compile(r"([^\.():,\s]+)$"),
     # This matches everything except a space.
-    "all_punctuations": re.compile("([^\s]+)$"),
+    "all_punctuations": re.compile(r"([^\s]+)$"),
 }
 
 
 def last_word(text, include="alphanum_underscore"):
-    """
+    R"""
     Find the last word in a sentence.
 
     >>> last_word('abc')
@@ -41,9 +41,9 @@ def last_word(text, include="alphanum_underscore"):
     >>> last_word('bac $def', include='most_punctuations')
     '$def'
     >>> last_word('bac \def', include='most_punctuations')
-    '\\\\def'
+    '\\def'
     >>> last_word('bac \def;', include='most_punctuations')
-    '\\\\def;'
+    '\\def;'
     >>> last_word('bac::def', include='most_punctuations')
     'def'
     """

--- a/litecli/packages/special/iocommands.py
+++ b/litecli/packages/special/iocommands.py
@@ -121,7 +121,7 @@ def get_editor_query(sql):
     # The reason we can't simply do .strip('\e') is that it strips characters,
     # not a substring. So it'll strip "e" in the end of the sql also!
     # Ex: "select * from style\e" -> "select * from styl".
-    pattern = re.compile("(^\\\e|\\\e$)")
+    pattern = re.compile(r"(^\\e|\\e$)")
     while pattern.search(sql):
         sql = pattern.sub("", sql)
 
@@ -245,7 +245,7 @@ def subst_favorite_query_args(query, args):
                 + query,
             ]
 
-    match = re.search("\\?|\\$\d+", query)
+    match = re.search(r"\?|\$\d+", query)
     if match:
         return [
             None,

--- a/litecli/sqlcompleter.py
+++ b/litecli/sqlcompleter.py
@@ -257,7 +257,7 @@ class SQLCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = compile("^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = compile(r"^[_a-z][_a-z0-9\$]*$")
 
         self.special_commands = []
         self.table_formats = supported_formats

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -309,7 +309,7 @@ def test_favorite_query_expanded_output(executor):
     results = run(executor, "\\fs test-ae select * from test")
     assert_result_equal(results, status="Saved.")
 
-    results = run(executor, "\\f+ test-ae \G")
+    results = run(executor, R"\f+ test-ae \G")
     assert is_expanded_output() is True
     assert_result_equal(
         results,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

On Python 3.12, litecli triggers several `SyntaxWarning`s about invalid escape sequences. On previous versions of Python, this was simply a `DeprecationWarning` and could only be seen with `-Wall`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG.md` file.
