### PR TITLE
Do not install tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming - TBD
+
+### Bug Fixes
+
+* Don't install tests
+
 ## 1.12.1  - 2024-09-07
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["screenshots"]
+exclude = ["screenshots", "tests*"]
 
 [tool.setuptools.package-data]
 litecli = ["liteclirc", "AUTHORS"]


### PR DESCRIPTION
## Description

I am the package maintainer for Gentoo. The package manager complains that tests are installed as part of the packages, but are not not necessary for runtime. This PR adds the tests to the exclusion list.

## Checklist

- [x] I've added this contribution to the `CHANGELOG.md` file.
