### PR TITLE
Specify build system in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming - TBD
+
+### Bug Fixes
+
+* Specify build system in `pyproject.toml`
+
 ## 1.12.1  - 2024-09-07
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 ]
 
 [build-system]
+requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "sqlparse>=0.4.4",
 ]
 
+[build-system]
+build-backend = "setuptools.build_meta"
 
 [project.scripts]
 litecli = "litecli.main:cli"


### PR DESCRIPTION
## Description

I am the package maintainer for Gentoo. The package manager complains that the build system is not specified in `pyproject.toml`. This PR adds the required lines.

## Checklist

- [x] I've added this contribution to the `CHANGELOG.md` file.
