### PR TITLE
Fix completion error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-* Fix the windows path shown in prompt to remove escaping.
+* Fix the [windows path](https://github.com/dbcli/litecli/issues/187) shown in prompt to remove escaping.
+* Fix a bug where if column name was same as table name it was [crashing](https://github.com/dbcli/litecli/issues/155) the autocompletion.
 
 ### Internal
 

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -32,7 +32,7 @@ class SQLExecute(object):
     table_columns_query = """
         SELECT m.name as tableName, p.name as columnName
         FROM sqlite_master m
-        LEFT OUTER JOIN pragma_table_info((m.name)) p ON m.name <> p.name
+        JOIN pragma_table_info((m.name)) p
         WHERE m.type IN ('table','view') AND m.name NOT LIKE 'sqlite_%'
         ORDER BY tableName, columnName
     """

--- a/tests/test_sqlexecute.py
+++ b/tests/test_sqlexecute.py
@@ -38,13 +38,15 @@ def test_binary(executor):
 
 
 ## Failing in Travis for some unknown reason.
-# @dbtest
-# def test_table_and_columns_query(executor):
-#     run(executor, "create table a(x text, y text)")
-#     run(executor, "create table b(z text)")
+@dbtest
+def test_table_and_columns_query(executor):
+    run(executor, "create table a(x text, y text)")
+    run(executor, "create table b(z text)")
+    run(executor, "create table t(t text)")
 
-#     assert set(executor.tables()) == set([("a",), ("b",)])
-#     assert set(executor.table_columns()) == set([("a", "x"), ("a", "y"), ("b", "z")])
+    assert set(executor.tables()) == set([("a",), ("b",), ("t",)])
+    assert set(executor.table_columns()) == set([("a", "x"), ("a", "y"), ("b", "z"), ("t", "t")])
+    assert set(executor.table_columns()) == set([("a", "x"), ("a", "y"), ("b", "z"), ("t", "t")])
 
 
 @dbtest


### PR DESCRIPTION
When a table had a column by the same name, the column name was returned as null.

eg: "create table t (t text)"  would return the table name as t and column name as null.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG.md` file.
