### PR TITLE
Don't display rows affected when the connector tells us -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug Fixes
+
+* Fix [misleading "0 rows affected" status for CTEs](https://github.com/dbcli/litecli/issues/203)
+  by never displaying rows affected when the connector tells us -1
+
 ## 1.14.2 - 2025-01-26
 
 ### Bug Fixes

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -138,16 +138,19 @@ class SQLExecute(object):
         # e.g. SELECT.
         if cursor.description is not None:
             headers = [x[0] for x in cursor.description]
-            status = "{0} row{1} in set"
+            status = "{count} row{s} in set"
             cursor = list(cursor)
             rowcount = len(cursor)
         else:
             _logger.debug("No rows in result.")
-            status = "Query OK, {0} row{1} affected"
-            rowcount = 0 if cursor.rowcount == -1 else cursor.rowcount
+            if cursor.rowcount == -1:
+                status = "Query OK"
+            else:
+                status = "Query OK, {count} row{s} affected"
+            rowcount = cursor.rowcount
             cursor = None
 
-        status = status.format(rowcount, "" if rowcount == 1 else "s")
+        status = status.format(count=rowcount, s="" if rowcount == 1 else "s")
 
         return (title, cursor, headers, status)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

We have been displaying "0 rows affected" in this case, but that is
misleading for CTEs, which could affect any number of rows.

Fixes #203

## Manual Testing

```
(venv) dhashe@Aurelius litecli $ litecli -D :memory:
LiteCli: 1.14.3.dev1+geedfef6 (SQLite: 3.37.2)
GitHub: https://github.com/dbcli/litecli
:memory:> create table data (
              id INTEGER PRIMARY KEY
          );
Query OK
Time: 0.001s
:memory:> with temp as (
              select 1 as id
          )
          insert into data select id from temp;
Query OK
Time: 0.001s
:memory:> select * from data;
+----+
| id |
+----+
| 1  |
+----+
1 row in set
Time: 0.017s
:memory:> update data set id = 2;
Query OK, 1 row affected
Time: 0.001s
:memory:> insert into data (id) values (3), (4);
Query OK, 2 rows affected
Time: 0.001s
:memory:>
```


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG.md` file.
