### PR TITLE
Check for a DB connection before running an LLM query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## TBD
+## 1.14.3 - 2025-01-29
 
 ### Bug Fixes
 
 * Fix [misleading "0 rows affected" status for CTEs](https://github.com/dbcli/litecli/issues/203)
   by never displaying rows affected when the connector tells us -1
+* Show an error message when `\llm "question"` is invoked without a database connection.
 
 ## 1.14.2 - 2025-01-26
 

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -444,7 +444,7 @@ class LiteCli(object):
                 if special.is_llm_command(text):
                     try:
                         start = time()
-                        cur = self.sqlexecute.conn.cursor()
+                        cur = self.sqlexecute.conn and self.sqlexecute.conn.cursor()
                         context, sql = special.handle_llm(text, cur)
                         if context:
                             click.echo(context)

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -285,6 +285,8 @@ def is_llm_command(command) -> bool:
 
 @export
 def sql_using_llm(cur, question=None, verbose=False) -> Tuple[str, Optional[str]]:
+    if cur is None:
+        raise RuntimeError("Connect to a datbase and try again.")
     schema_query = """
         SELECT sql FROM sqlite_master
         WHERE sql IS NOT NULL


### PR DESCRIPTION
## Description
When no database is connected and user tries to run `\llm "Question?"` it shows a useful error.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG.md` file.
