### PR TITLE
Make history file configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## TBD
+
+### Features
+
+* Make the history file location configurable. ([#206](https://github.com/dbcli/litecli/issues/206))
+
 ## 1.14.4 - 2025-01-31
 
 ### Bug Fixes

--- a/litecli/liteclirc
+++ b/litecli/liteclirc
@@ -18,6 +18,12 @@ destructive_warning = True
 # %USERPROFILE% is typically C:\Users\{username}
 log_file = default
 
+# history_file location.
+# In Unix/Linux: ~/.config/litecli/history
+# In Windows: %USERPROFILE%\AppData\Local\dbcli\litecli\history
+# %USERPROFILE% is typically C:\Users\{username}
+history_file = default
+
 # Default log level. Possible values: "CRITICAL", "ERROR", "WARNING", "INFO"
 # and "DEBUG". "NONE" disables logging.
 log_level = INFO

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -352,7 +352,10 @@ class LiteCli(object):
         self.configure_pager()
         self.refresh_completions()
 
-        history_file = config_location() + "history"
+        history_file = self.config["main"]["history_file"]
+        if history_file == "default":
+            history_file = config_location() + "history"
+        history_file = os.path.expanduser(history_file)
         if dir_path_exists(history_file):
             history = FileHistory(history_file)
         else:


### PR DESCRIPTION
## Description

Add a `history_file` option to the config file. Matches the behavior of
pgcli and mssql-cli.

Fixes #206

# Manual testing

Verify that the default history location still works:

```
$ litecli :memory:

LiteCli: 1.14.3.dev1+geedfef6 (SQLite: 3.37.2)
GitHub: https://github.com/dbcli/litecli
:memory:> select 42;
+----+
| 42 |
+----+
| 42 |
+----+
1 row in set
Time: 0.015s
:memory:>
Goodbye!

$ tail -2 ~/.config/litecli/history
# 2025-02-16 16:21:26.052905
+select 42;
```

Check that custom history locations work and will be created if not present:

```
$ stat ~/.my_nonstandard_litecli_history_file
stat: cannot statx '/home/dhashe/.my_nonstandard_litecli_history_file': No such file or directory

$ sed -i '2a history_file = ~/.my_nonstandard_litecli_history_file' ~/.config/litecli/config

$ litecli :memory:

LiteCli: 1.14.3.dev1+geedfef6 (SQLite: 3.37.2)
GitHub: https://github.com/dbcli/litecli
:memory:> select 43;
+----+
| 43 |
+----+
| 43 |
+----+
1 row in set
Time: 0.017s
:memory:>
Goodbye!

$ cat ~/.my_nonstandard_litecli_history_file

# 2025-02-16 16:31:02.120200
+select 43;
```

## Checklist

- [x] I've added this contribution to the `CHANGELOG.md` file.
