### PR TITLE
Improve prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.14.5 - 2025-02-17
 
-### Internal
+### Bug Fixes
 
 * Enhance llm prompt to include each SQL query in a separate code fence.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Internal
 
-* Enhance llm prompt to include on SQL query in code fence.
+* Enhance llm prompt to include each SQL query in a separate code fence.
 
 ## 1.14.4 - 2025-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Internal
 
-* Fix typo `pormpt`to `prompt` in `special/llm.py`.
+* Enhance llm prompt to include on SQL query in code fence.
 
 ## 1.14.4 - 2025-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.14.5 - 2025-02-17
+
+### Internal
+
+* Fix typo `pormpt`to `prompt` in `special/llm.py`.
+
 ## 1.14.4 - 2025-01-31
 
 ### Bug Fixes

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -163,12 +163,12 @@ $question
 
 Explain the reason for choosing each table in the SQL query you have
 written. Keep the explanation concise.
+When the user request for multiple sql queries, include each SQL query in a separate code fence.
 Finally include a sql query in a code fence such as this one:
 
 ```sql
 SELECT count(*) FROM table_name;
 ```
-When the user requests for multiple sql queries, separate them with in a separate code fence.
 """
 
 

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -222,7 +222,7 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str]]:
     if "-c" in parts:
         capture_output = True
         use_context = False
-    # If the parts has `pormpt` command without `-c` then use context to the prompt.
+    # If the parts has `prompt` command without `-c` then use context to the prompt.
     # \llm -m ollama prompt "Most visited urls?"
     elif "prompt" in parts:  # User might invoke prompt with an option flag in the first argument.
         capture_output = True

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -168,6 +168,7 @@ Finally include a sql query in a code fence such as this one:
 ```sql
 SELECT count(*) FROM table_name;
 ```
+When the user requests for multiple sql queries, separate them with in a separate code fence.
 """
 
 
@@ -222,7 +223,7 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str]]:
     if "-c" in parts:
         capture_output = True
         use_context = False
-    # If the parts has `prompt` command without `-c` then use context to the prompt.
+    # If the parts has `pormpt` command without `-c` then use context to the prompt.
     # \llm -m ollama prompt "Most visited urls?"
     elif "prompt" in parts:  # User might invoke prompt with an option flag in the first argument.
         capture_output = True


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

- When the LLM response returns multiple SQL queries, all the SQL queries are clubbed inside the single code fence. Improve the prompt to return a SQL per code fence.
- Fixes https://github.com/dbcli/litecli/issues/209
- *Note*: `ensure_litecli_template(replace=False)` is called with False, that means it's hard to change the prompt in the future. Updating the template requires the editor. May be suffixing the version of the installation in the template name can help. I'm happy to modify the code if needed. 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `CHANGELOG.md` file.
