### PR TITLE
[llm] Add support for --help flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## TBD
 
 ### Features
-
+* Support `--help` in the `\llm`and `\llm+` command. ([#214](https://github.com/dbcli/litecli/pull/214))
 * Make the history file location configurable. ([#206](https://github.com/dbcli/litecli/issues/206))
 
 ### Internal

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -236,6 +236,10 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str]]:
     elif parts[0] in LLM_CLI_COMMANDS:
         capture_output = False
         use_context = False
+    # If the user wants to use --help option to see each command and it's description
+    elif "--help" == parts[0]:
+        capture_output = False
+        use_context = False
     # If the parts doesn't have any known LLM_CLI_COMMANDS then the user is
     # invoking a question. eg: \llm -m ollama "Most visited urls?"
     elif not set(parts).intersection(LLM_CLI_COMMANDS):

--- a/tests/test_llm_special.py
+++ b/tests/test_llm_special.py
@@ -87,6 +87,23 @@ def test_llm_command_known_subcommand(mock_run_cmd, mock_llm, executor):
     # And the function should raise FinishIteration(None)
     assert exc_info.value.args[0] is None
 
+@patch("litecli.packages.special.llm.llm")
+@patch("litecli.packages.special.llm.run_external_cmd")
+def test_llm_command_with_help_flag(mock_run_cmd, mock_llm, executor):
+    """
+    If the parts[0] is --help, we do NOT capture output, we just call run_external_cmd
+    and then raise FinishIteration.
+    """
+    # Let's assume 'models' is in LLM_CLI_COMMANDS
+    test_text = r"\llm --help"
+
+    with pytest.raises(FinishIteration) as exc_info:
+        handle_llm(test_text, executor)
+
+    # We check that run_external_cmd was called with these arguments:
+    mock_run_cmd.assert_called_once_with("llm", "--help", restart_cli=False)
+    # And the function should raise FinishIteration(None)
+    assert exc_info.value.args[0] is None
 
 @patch("litecli.packages.special.llm.llm")
 @patch("litecli.packages.special.llm.run_external_cmd")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

1. `\llm`and `\\m+`supports all the native commands of the llm python cli tool but misses the `--help`flag. 
2. The PR adds the `--help` flag support to the tool.

Here is a sample input and output
```python
uv run litecli /Users/kracekumar/code/mcp-chatbot/test.db
LiteCli: 0.1.dev429+g5be771e (SQLite: 3.47.1)
GitHub: https://github.com/dbcli/litecli
/Users/kracekumar/code/mcp-chatbot/test.db> \llm --help
Usage: llm [OPTIONS] COMMAND [ARGS]...

  Access Large Language Models from the command-line

  Documentation: https://llm.datasette.io/

  LLM can run models from many different providers. Consult the plugin
  directory for a list of available models:

  https://llm.datasette.io/en/stable/plugins/directory.html

  To get started with OpenAI, obtain an API key from them and:

      $ llm keys set openai
      Enter key: ...

  Then execute a prompt like this:

      llm 'Five outrageous names for a pet pelican'

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  prompt*       Execute a prompt
  aliases       Manage model aliases
  chat          Hold an ongoing chat with a model.
  collections   View and manage collections of embeddings
  embed         Embed text and store or return the result
  embed-models  Manage available embedding models
  embed-multi   Store embeddings for multiple strings at once
  install       Install packages from PyPI into the same environment as LLM
  keys          Manage stored API keys for different models
  logs          Tools for exploring logged prompts and responses
  models        Manage available models
  openai        Commands for working directly with the OpenAI API
  plugins       List installed plugins
  similar       Return top N similar IDs from a collection
  templates     Manage stored prompt templates
  uninstall     Uninstall Python packages from the LLM environment
/Users/kracekumar/code/mcp-chatbot/test.db> \llm+ --help
Usage: llm [OPTIONS] COMMAND [ARGS]...

  Access Large Language Models from the command-line

  Documentation: https://llm.datasette.io/

  LLM can run models from many different providers. Consult the plugin
  directory for a list of available models:

  https://llm.datasette.io/en/stable/plugins/directory.html

  To get started with OpenAI, obtain an API key from them and:

      $ llm keys set openai
      Enter key: ...

  Then execute a prompt like this:

      llm 'Five outrageous names for a pet pelican'

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  prompt*       Execute a prompt
  aliases       Manage model aliases
  chat          Hold an ongoing chat with a model.
  collections   View and manage collections of embeddings
  embed         Embed text and store or return the result
  embed-models  Manage available embedding models
  embed-multi   Store embeddings for multiple strings at once
  install       Install packages from PyPI into the same environment as LLM
  keys          Manage stored API keys for different models
  logs          Tools for exploring logged prompts and responses
  models        Manage available models
  openai        Commands for working directly with the OpenAI API
  plugins       List installed plugins
  similar       Return top N similar IDs from a collection
  templates     Manage stored prompt templates
  uninstall     Uninstall Python packages from the LLM environment
/Users/kracekumar/code/mcp-chatbot/test.db>
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG.md` file.
