### PR TITLE
[LLM] Add logs while executing llm command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## TBD
 
 ### Features
+* Add logs while invoking `\llm`and `\\m+` command. [(#215)](https://github.com/dbcli/litecli/pull/215)
 * Support `--help` in the `\llm`and `\llm+` command. ([#214](https://github.com/dbcli/litecli/pull/214))
 * Make the history file location configurable. ([#206](https://github.com/dbcli/litecli/issues/206))
 

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -448,13 +448,12 @@ class LiteCli(object):
                     try:
                         start = time()
                         cur = self.sqlexecute.conn and self.sqlexecute.conn.cursor()
-                        click.echo("Calling llm command")
                         context, sql, duration = special.handle_llm(text, cur)
                         if context:
                             click.echo("LLM Reponse:")
                             click.echo(context)
                             click.echo('---')
-                        click.echo(f"llm command took {duration:.2f} seconds to complete the operation")
+                        click.echo(f"Time: {duration:.2f} seconds")
                         text = self.prompt_app.prompt(default=sql)
                     except KeyboardInterrupt:
                         return

--- a/litecli/main.py
+++ b/litecli/main.py
@@ -448,9 +448,13 @@ class LiteCli(object):
                     try:
                         start = time()
                         cur = self.sqlexecute.conn and self.sqlexecute.conn.cursor()
-                        context, sql = special.handle_llm(text, cur)
+                        click.echo("Calling llm command")
+                        context, sql, duration = special.handle_llm(text, cur)
                         if context:
+                            click.echo("LLM Reponse:")
                             click.echo(context)
+                            click.echo('---')
+                        click.echo(f"llm command took {duration:.2f} seconds to complete the operation")
                         text = self.prompt_app.prompt(default=sql)
                     except KeyboardInterrupt:
                         return

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -273,7 +273,7 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str], float]:
     try:
         ensure_litecli_template()
         # Measure end to end llm command invocation.
-        # This measures the internal DB command to pull the schema
+        # This measures the internal DB command to pull the schema and llm command
         start = time.perf_counter()
         context, sql = sql_using_llm(cur=cur, question=arg, verbose=verbose)
         end = time.perf_counter()

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -254,6 +254,7 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str], float]:
     if not use_context:
         args = parts
         if capture_output:
+            click.echo("Calling llm command")
             start = time.perf_counter()
             _, result = run_external_cmd("llm", *args, capture_output=capture_output)
             end = time.perf_counter()
@@ -307,6 +308,7 @@ def sql_using_llm(cur, question=None, verbose=False) -> Tuple[str, Optional[str]
             WHERE type IN ('table','view') AND name NOT LIKE 'sqlite_%'
             ORDER BY 1
     """
+    click.echo("Preparing schema information to feed the llm")
     sample_row_query = "SELECT * FROM {table} LIMIT 1"
     log.debug(schema_query)
     cur.execute(schema_query)
@@ -338,7 +340,9 @@ def sql_using_llm(cur, question=None, verbose=False) -> Tuple[str, Optional[str]
         question,
         " ",  # Dummy argument to prevent llm from waiting on stdin
     ]
+    click.echo("Invoking llm command with schema information")
     _, result = run_external_cmd("llm", *args, capture_output=True)
+    click.echo("Received response from the llm command")
     match = re.search(_SQL_CODE_FENCE, result, re.DOTALL)
     if match:
         sql = match.group(1).strip()

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -7,7 +7,7 @@ import shlex
 import sys
 from runpy import run_module
 from typing import Optional, Tuple
-import time
+from time import time
 
 import click
 
@@ -255,9 +255,9 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str], float]:
         args = parts
         if capture_output:
             click.echo("Calling llm command")
-            start = time.perf_counter()
+            start = time()
             _, result = run_external_cmd("llm", *args, capture_output=capture_output)
-            end = time.perf_counter()
+            end = time()
             match = re.search(_SQL_CODE_FENCE, result, re.DOTALL)
             if match:
                 sql = match.group(1).strip()
@@ -274,9 +274,9 @@ def handle_llm(text, cur) -> Tuple[str, Optional[str], float]:
         ensure_litecli_template()
         # Measure end to end llm command invocation.
         # This measures the internal DB command to pull the schema and llm command
-        start = time.perf_counter()
+        start = time()
         context, sql = sql_using_llm(cur=cur, question=arg, verbose=verbose)
-        end = time.perf_counter()
+        end = time()
         if not verbose:
             context = ""
         return context, sql, end - start

--- a/tests/test_llm_special.py
+++ b/tests/test_llm_special.py
@@ -59,7 +59,7 @@ def test_llm_command_with_c_flag_and_fenced_sql(mock_run_cmd, mock_llm, executor
 
     test_text = r"\llm -c 'Rewrite the SQL without CTE'"
 
-    result, sql = handle_llm(test_text, executor)
+    result, sql, duration = handle_llm(test_text, executor)
 
     # We expect the function to return (result, sql), but result might be "" if verbose is not set
     # By default, `verbose` is false unless text has something like \llm --verbose?
@@ -67,6 +67,7 @@ def test_llm_command_with_c_flag_and_fenced_sql(mock_run_cmd, mock_llm, executor
     # Our test_text doesn't set verbose => we expect "" for the returned context.
     assert result == ""
     assert sql == "SELECT * FROM table;"
+    assert isinstance(duration, float)
 
 
 @patch("litecli.packages.special.llm.llm")
@@ -133,7 +134,7 @@ def test_llm_command_with_prompt(mock_sql_using_llm, mock_ensure_template, mock_
     mock_sql_using_llm.return_value = ("context from LLM", "SELECT 1;")
 
     test_text = r"\llm prompt 'Magic happening here?'"
-    context, sql = handle_llm(test_text, executor)
+    context, sql, duration = handle_llm(test_text, executor)
 
     # ensure_litecli_template should be called
     mock_ensure_template.assert_called_once()
@@ -143,6 +144,7 @@ def test_llm_command_with_prompt(mock_sql_using_llm, mock_ensure_template, mock_
     mock_sql_using_llm.assert_called()
     assert context == ""
     assert sql == "SELECT 1;"
+    assert isinstance(duration, float)
 
 
 @patch("litecli.packages.special.llm.llm")
@@ -155,12 +157,13 @@ def test_llm_command_question_with_context(mock_sql_using_llm, mock_ensure_templ
     mock_sql_using_llm.return_value = ("You have context!", "SELECT 2;")
 
     test_text = r"\llm 'Top 10 downloads by size.'"
-    context, sql = handle_llm(test_text, executor)
+    context, sql, duration = handle_llm(test_text, executor)
 
     mock_ensure_template.assert_called_once()
     mock_sql_using_llm.assert_called()
     assert context == ""
     assert sql == "SELECT 2;"
+    assert isinstance(duration, float)
 
 
 @patch("litecli.packages.special.llm.llm")
@@ -173,7 +176,9 @@ def test_llm_command_question_verbose(mock_sql_using_llm, mock_ensure_template, 
     mock_sql_using_llm.return_value = ("Verbose context, oh yeah!", "SELECT 42;")
 
     test_text = r"\llm+ 'Top 10 downloads by size.'"
-    context, sql = handle_llm(test_text, executor)
+    context, sql, duration = handle_llm(test_text, executor)
 
     assert context == "Verbose context, oh yeah!"
     assert sql == "SELECT 42;"
+
+    assert isinstance(duration, float)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
1. Since llm command fetches the schema of the database, creates a prompt and then invokes the llm command with the prompt. add a couple of log lines to indicate to user about the progress.
2. The PR measures entire end to end invocation of the command. The output message is different for `run_external_cmd` that is directly invoked and invoked via `sql_using_llm`.
3. I'm happy to modify the messages or colors to make more useful. I have skipped using emojis and sticked with simple useful messages.
4. Example Outputs:
```python
/Users/kracekumar/code/mcp-chatbot/test.db> \llm+ "Show only the top 5 results"
Preparing schema information to feed the llm
Invoking llm command with schema information
Received response from the llm command
LLM Reponse:
...
Explanation:

- We join `people`, `groups`, and `contact_groups` tables to get the required data.
- We use a window function (`ROW_NUMBER()`) to assign a unique number to each person based on their contact_id and group_id. This allows us to sort the results in descending order of these fields.
- The outer query then selects only the top 5 people by filtering `row_num` to be less than or equal to 5.

...

Explanation:

- This query simply counts the number of groups in the database, which represents the total number of people in contact groups.

---
Time: 6.07 seconds
....
/Users/kracekumar/code/mcp-chatbot/test.db> \llm+ -m codellama -c "Show only the top 5 results"
Calling llm command
LLM Reponse:
...
Explanation:

- We join `people`, `groups`, and `contact_groups` tables to get the required data.
- We use a window function (`ROW_NUMBER()`) to assign a unique number to each person based on their contact_id and group_id. This allows us to sort the results in descending order of these fields.
- The outer query then selects only the top 5 people by filtering `row_num` to be less than or equal to 5.
...

Explanation:

- This query simply counts the number of groups in the database, which represents the total number of people in contact groups.

---
Time: 15.61 seconds
```




## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `CHANGELOG.md` file.
