### PR TITLE
update pip install in contribution guide to handle zsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 
 * Fix typo `pormpt`to `prompt` in `special/llm.py`.
+* Update pip install to work in both bash and zsh.
 
 
 ## 1.14.4 - 2025-01-31

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ You'll always get credit for your work.
 5. Install the dependencies and development tools:
 
     ```bash
-    $ pip install --editable .[dev]
+    $ pip install --editable ".[dev]"
     ```
 
 6. Create a branch for your bugfix or feature based off the `main` branch:


### PR DESCRIPTION
## Description

Update pip install in contribution guide to handle zsh. My thinking here was that given zsh is the now macOS default there might be others who run into this.

## Checklist

- [x] I've added this contribution to the `CHANGELOG.md` file.
