### PR TITLE
Do not escape the upper case names

### DIFF
--- a/litecli/sqlcompleter.py
+++ b/litecli/sqlcompleter.py
@@ -258,7 +258,7 @@ class SQLCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = compile(r"^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = compile(r"^[_a-zA-Z][_a-zA-Z0-9\$]*$")
 
         self.special_commands = []
         self.table_formats = supported_formats

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -40,6 +40,18 @@ def complete_event():
     return Mock()
 
 
+def test_escape_name(completer):
+
+    for name, expected_name in [# Upper case name shouldn't be escaped
+        ("BAR", "BAR"),
+        # This name is escaped and should start with back tick
+        ("2025todos", "`2025todos`"),
+        # normal case
+        ("people", "people"),
+        # table name with _underscore should not be escaped
+        ("django_users", "django_users")]:
+        assert completer.escape_name(name) == expected_name
+
 def test_empty_string_completion(completer, complete_event):
     text = ""
     position = 0


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

- Previously when the table was upper case, the escaped name had a `back tick`.
- Now it skips by modifying the regex to mathc the pattern
- screenshot

<img width="462" alt="Screenshot 2025-03-02 at 2 52 28 pm" src="https://github.com/user-attachments/assets/31f5b060-74c6-4874-9384-b65eb39f40a8" />
<img width="462" alt="Screenshot 2025-03-02 at 2 52 41 pm" src="https://github.com/user-attachments/assets/42089678-631e-4b7c-b4ce-c7acf56ecd11" />

- Fixes #185 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG.md` file.
