### PR TITLE
Return indexes when .schema is run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix a bug where the `\llm` command on alternate invocations weren't detected correctly. (#211)
 * Do not escape upper table or column name. [(#185)](https://github.com/dbcli/litecli/issues/185)
+* Return indices when `.schema` command is run. Also update the output to contain the `sql` for the `indexes` command. [(#149)](https://github.com/dbcli/litecli/issues/149)
 
 ### Internal
 

--- a/litecli/packages/special/dbcommands.py
+++ b/litecli/packages/special/dbcommands.py
@@ -68,7 +68,7 @@ def show_schema(cur, arg=None, **_):
         args = (arg,)
         query = """
             SELECT sql FROM sqlite_master
-            WHERE name==? AND sql IS NOT NULL
+            WHERE tbl_name==? AND sql IS NOT NULL
             ORDER BY tbl_name, type DESC, name
         """
     else:
@@ -86,9 +86,9 @@ def show_schema(cur, arg=None, **_):
     if cur.description:
         headers = [x[0] for x in cur.description]
     else:
-        return [(None, None, None, "")] + _list_indexes(cur, arg=arg)
+        return [(None, None, None, "")]
 
-    return [(None, tables, headers, status)] + _list_indexes(cur, arg=arg)
+    return [(None, tables, headers, status)]
 
 @special_command(
     ".databases",
@@ -108,9 +108,15 @@ def list_databases(cur, **_):
     else:
         return [(None, None, None, "")]
 
-
-# This is private to make sure .schemas special command can call the function to retreive the index
-def _list_indexes(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
+@special_command(
+    ".indexes",
+    ".indexes [tablename]",
+    "List indexes.",
+    arg_type=PARSED_QUERY,
+    case_sensitive=True,
+    aliases=("\\di",),
+)
+def list_indexes(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
     if arg:
         args = ("{0}%".format(arg),)
         query = """
@@ -135,17 +141,6 @@ def _list_indexes(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
     else:
         return [(None, None, None, "")]
     return [(None, indexes, headers, status)]
-
-@special_command(
-    ".indexes",
-    ".indexes [tablename]",
-    "List indexes.",
-    arg_type=PARSED_QUERY,
-    case_sensitive=True,
-    aliases=("\\di",),
-)
-def list_indexes(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
-    return _list_indexes(cur, arg=arg, arg_type=arg_type, verbose=verbose)
 
 
 @special_command(

--- a/litecli/packages/special/llm.py
+++ b/litecli/packages/special/llm.py
@@ -20,6 +20,8 @@ try:
 except ImportError:
     llm = None
     cli = None
+    LLM_CLI_COMMANDS = []
+    MODELS = {}
 
 from . import export
 from .main import parse_special_command

--- a/litecli/sqlexecute.py
+++ b/litecli/sqlexecute.py
@@ -38,7 +38,7 @@ class SQLExecute(object):
     """
 
     indexes_query = """
-        SELECT name
+        SELECT name, sql
         FROM sqlite_master
         WHERE type = 'index' AND name NOT LIKE 'sqlite_%'
         ORDER BY 1


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
1. As per https://github.com/dbcli/litecli/issues/149. the `.schema` command doesnot return index associated with the table.
2. The sqlite special command, `.schema`command returns so.
3. This PR calls the special command list_indexes to adhere to the similar behaviour
4. *Breaking Change*: Before when `.index` command is run only name was returned, now both name and SQL is returned that is similar to sqlite

### Examples
1. Sqlite
```sql
sqlite> .schema
CREATE TABLE u (name TEXT) STRICT;
CREATE TABLE u1 (name TEXT) STRICT;
CREATE TABLE u2 (name TEXT) STRICT;
CREATE TABLE u3 (name TEXT) STRICT;
CREATE TABLE u4 (name TEXT) STRICT;
CREATE TABLE people (
  person_id VARCHAR PRIMARY KEY,
  name VARCHAR,
  born INTEGER,
  died INTEGER
);
CREATE INDEX ix_people_name ON people (name);
CREATE TABLE people1(
  person_id VARCHAR PRIMARY KEY,
  name VARCHAR,
  born INTEGER,
  died INTEGER
);
CREATE INDEX ix_people_name_1 ON people (name);
CREATE INDEX ix_people_name_2 ON people1 (name);

sqlite> .schema people
CREATE TABLE people (
  person_id VARCHAR PRIMARY KEY,
  name VARCHAR,
  born INTEGER,
  died INTEGER
);
CREATE INDEX ix_people_name ON people (name);
CREATE INDEX ix_people_name_1 ON people (name);
``` 

2. LiteCLI
```sql
./test.db> .schema
+-------------------------------------------------+
| sql                                             |
+-------------------------------------------------+
| CREATE TABLE people (                           |
|   person_id VARCHAR PRIMARY KEY,                |
|   name VARCHAR,                                 |
|   born INTEGER,                                 |
|   died INTEGER                                  |
| )                                               |
| CREATE INDEX ix_people_name ON people (name)    |
| CREATE INDEX ix_people_name_1 ON people (name)  |
| CREATE TABLE people1(                           |
|   person_id VARCHAR PRIMARY KEY,                |
|   name VARCHAR,                                 |
|   born INTEGER,                                 |
|   died INTEGER                                  |
| )                                               |
| CREATE INDEX ix_people_name_2 ON people1 (name) |
| CREATE TABLE u (name TEXT) STRICT               |
| CREATE TABLE u1 (name TEXT) STRICT              |
| CREATE TABLE u2 (name TEXT) STRICT              |
| CREATE TABLE u3 (name TEXT) STRICT              |
| CREATE TABLE u4 (name TEXT) STRICT              |
+-------------------------------------------------+
Time: 0.004s

+------------------+-------------------------------------------------+
| name             | sql                                             |
+------------------+-------------------------------------------------+
| ix_people_name   | CREATE INDEX ix_people_name ON people (name)    |
| ix_people_name_1 | CREATE INDEX ix_people_name_1 ON people (name)  |
| ix_people_name_2 | CREATE INDEX ix_people_name_2 ON people1 (name) |
+------------------+-------------------------------------------------+

../test.db> .schema people;
+----------------------------------+
| sql                              |
+----------------------------------+
| CREATE TABLE people (            |
|   person_id VARCHAR PRIMARY KEY, |
|   name VARCHAR,                  |
|   born INTEGER,                  |
|   died INTEGER                   |
| )                                |
+----------------------------------+
Time: 0.004s

+------------------+-------------------------------------------------+
| name             | sql                                             |
+------------------+-------------------------------------------------+
| ix_people_name   | CREATE INDEX ix_people_name ON people (name)    |
| ix_people_name_1 | CREATE INDEX ix_people_name_1 ON people (name)  |
| ix_people_name_2 | CREATE INDEX ix_people_name_2 ON people1 (name) |
+------------------+-------------------------------------------------+
Time: 0.003s
../test.db>
```


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `CHANGELOG.md` file.
