### PR TITLE
Resolve daemon warnings for threading methods

### DIFF
--- a/litecli/completion_refresher.py
+++ b/litecli/completion_refresher.py
@@ -42,7 +42,7 @@ class CompletionRefresher(object):
                     args=(executor, callbacks, completer_options),
                     name="completion_refresh",
                 )
-                self._completer_thread.setDaemon(True)
+                self._completer_thread.daemon = True
                 self._completer_thread.start()
                 return [
                     (


### PR DESCRIPTION
## Description
This small PR resolve the deprecation warnings of daemon for threading methods:
```python
 /home/runner/work/litecli/litecli/litecli/completion_refresher.py:45: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `CHANGELOG.md` file.
