### PR TITLE
fix: resolve typecheck failures in `.load` command and tests utils

### DIFF
--- a/litecli/packages/special/dbcommands.py
+++ b/litecli/packages/special/dbcommands.py
@@ -254,7 +254,6 @@ def load_extension(cur: DBCursor, arg: str, **_: Any) -> None:
     conn = cur.connection
     conn.enable_load_extension(True)
     conn.load_extension(path)
-    return [(None, None, None, "")]
 
 
 @special_command(

--- a/litecli/packages/special/dbcommands.py
+++ b/litecli/packages/special/dbcommands.py
@@ -246,7 +246,7 @@ def status(cur: DBCursor, **_: Any) -> list[tuple]:
     arg_type=PARSED_QUERY,
     case_sensitive=True,
 )
-def load_extension(cur: DBCursor, arg: str, **_: Any) -> None:
+def load_extension(cur: DBCursor, arg: str, **_: Any) -> list[tuple]:
     args = shlex.split(arg)
     if len(args) != 1:
         raise TypeError(".load accepts exactly one path")
@@ -254,6 +254,7 @@ def load_extension(cur: DBCursor, arg: str, **_: Any) -> None:
     conn = cur.connection
     conn.enable_load_extension(True)
     conn.load_extension(path)
+    return [(None, None, None, "")]
 
 
 @special_command(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ DATABASE = "test.sqlite3"
 
 
 def db_connection(dbname=":memory:"):
-    conn = sqlite3.connect(database=dbname, isolation_level=None)  # type: ignore[attr-defined]
+    conn = sqlite3.connect(database=dbname, isolation_level=None)
     return conn
 
 


### PR DESCRIPTION
### Motivation
- Fix CI typecheck errors: the `.load` special command returned a value despite being annotated `-> None`, and tests included an unused `# type: ignore` suppression.

### Description
- Removed the stray `return [(None, None, None, "")]` from `load_extension` in `litecli/packages/special/dbcommands.py` and removed the unused `# type: ignore[attr-defined]` comment from `tests/utils.py`.

### Testing
- Performed `pip install -e .`, ran `ruff check litecli/packages/special/dbcommands.py tests/utils.py` which passed, and ran `pytest -q tests/test_dbspecial.py` which completed successfully (`9 passed`); attempted `ty check` but the `ty` tool was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699121ecb968832a9b6e1f7b4991e413)