### PR TITLE
Drop Python 3.9 from CI, tox, and pyproject targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Internal
 
 - Add a GitHub Actions workflow to run Codex review on pull requests.
+- Drop Python 3.9 from test matrices and tooling targets.
 
 ## 1.19.0 - 2026-01-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "litecli"
 dynamic = ["version"]
 description = "CLI for SQLite Databases with auto-completion and syntax highlighting."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "BSD" }
 authors = [{ name = "dbcli", email = "litecli-users@googlegroups.com" }]
 urls = { "homepage" = "https://github.com/dbcli/litecli" }
@@ -62,7 +62,7 @@ litecli = ["liteclirc", "AUTHORS"]
 line-length = 140
 
 [tool.ty.environment]
-python-version = "3.9"
+python-version = "3.10"
 root = [".", "litecli", "litecli/packages", "litecli/packages/special"]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py
+envlist = py,style,sqlean
 
 [testenv]
 deps = uv

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py311,py312,py313,style,sqlean
+envlist = py
 
 [testenv]
 deps = uv

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py,style,sqlean
+envlist = py310,py311,py312,py313,style,sqlean
 
 [testenv]
 deps = uv


### PR DESCRIPTION
### Motivation

- Remove Python 3.9 from automated test matrices and tooling targets to keep CI and tooling aligned with supported runtimes.
- Raise the minimum declared runtime to Python 3.10 to reflect the removal of 3.9 from testing and type-checking targets.
- Keep tox envlist explicit to avoid ambiguity about which Python versions are exercised in CI.

### Description

- Update GitHub Actions matrices to test only `3.10`–`3.13` by editing `.github/workflows/ci.yml` and `.github/workflows/publish.yml`.
- Change `tox.ini` envlist from the generic `py` to explicit environments `py310,py311,py312,py313,style,sqlean`.
- Bump project minimum Python in `pyproject.toml` from `>=3.9` to `>=3.10` and update `tool.ty.environment.python-version` from `3.9` to `3.10`.
- Add an Unreleased `CHANGELOG.md` entry noting the removal of Python 3.9 from test matrices and tooling targets.

### Testing

- Ran an environment-aware tox listing via `uv run --extra dev tox -l`, which succeeded and reported `py310`, `py311`, `py312`, `py313`, `style`, and `sqlean`.
- Attempting `tox -l` directly failed initially because `tox` was not installed in the global environment (expected in this workspace), and the workspace-local `uv` invocation was used to validate the envlist instead.
- Performed automated file checks to verify the updated files no longer reference `3.9` and confirmed the changes (no remaining `3.9` matches in the updated files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991220629a0832a9e38f28efb18c0d4)